### PR TITLE
[TASK] Require typo3/cms-core ^11.5 in composer.json

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,4 +1,4 @@
-[globalVar = GP:tx_news_pi1|news_preview > 0]
+[traverse(request.getQueryParams(), 'tx_news_pi1/news_preview') > 0]
     lib.yoastSEO.currentURL.stdWrap.typolink {
         addQueryString.exclude = type,tx_news_pi1[news_preview]
         additionalParams = &tx_news_pi1[news]={GP:tx_news_pi1|news_preview}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "yoast-seo-for-typo3/yoast_seo": "^5.0 || ^6 || ^7 || ^8",
     "georgringer/news": "^7.0 || ^8 || ^9",
-    "typo3/cms-core": "^8.7 || ^9.5 || ^10.4",
+    "typo3/cms-core": "^8.7 || ^9.5 || ^10.4 || ^11.5",
     "typo3/cms-extbase": "^8.7 || ^9.5 || ^10.4 || ^11.5",
     "php": "^7.0"
   },


### PR DESCRIPTION
Could not install the extension for TYPO3 11 as long as composer.json requires "typo3/cms-core": "^8.7 || ^9.5 || ^10.4".

So I added "^11.5" to make extension installable on TYPO3 11